### PR TITLE
Add LocalStack license requirement and standardize setup

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,7 @@ jobs:
     environment: default-env
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Load .env file
         uses: xom9ikk/dotenv@v2
@@ -34,7 +34,7 @@ jobs:
           load-mode: strict
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -62,7 +62,7 @@ jobs:
             install-awslocal: 'true'
             configuration: DEBUG=1
         env:
-            LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+            LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 
       - name: Deploy using CDK
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,31 @@
-.PHONY: deploy-localstack deploy-aws
+export AWS_ACCESS_KEY_ID ?= test
+export AWS_SECRET_ACCESS_KEY ?= test
+export AWS_DEFAULT_REGION=us-east-1
+SHELL := /bin/bash
+
+usage:		## Show this help
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$//' | sed -e 's/##//'
+
+install:	## Install dependencies
+	@which localstack || pip install localstack
+	@which awslocal || pip install awscli-local
+	@which cdklocal || npm install -g aws-cdk-local aws-cdk
+
+start:		## Start LocalStack
+	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
+	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
+
+stop:		## Stop LocalStack
+	@localstack stop
+
+ready:		## Wait until LocalStack is ready
+	@echo Waiting on the LocalStack container...
+	@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+
+logs:		## Save the logs in a separate file
+	@localstack logs > logs.txt
+
+.PHONY: usage install start stop ready logs deploy-localstack deploy-aws
 
 deploy-localstack:
 	@echo "Preparing deployment"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ LocalStack sample CDK app deploying a Kinesis Event Stream to Data Firehose to R
 
 # Prerequisites
 
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
+
 ## Required Software
 - Python 3.11
 - node >16
@@ -84,6 +86,16 @@ source .venv/bin/activate
 pip install -r requirements-dev.txt
 ```    
 
+
+## Start LocalStack
+
+Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
+
+```bash
+export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
+make start
+make ready
+```
 
 # Deployment
 - Configure the AWS CLI


### PR DESCRIPTION
## Summary

- Add license requirement bullet to Prerequisites section in README
- Add `start`, `stop`, `ready`, `logs`, `usage`, `install` targets to Makefile with auth guard
- Add Start LocalStack section to README using `make start` / `make ready` pattern
- Upgrade `actions/checkout` and `setup-node` to v4
- Replace `LOCALSTACK_API_KEY` with `LOCALSTACK_AUTH_TOKEN` in workflow
